### PR TITLE
Allow power user to set his own OAuth2 tokens for Google provider

### DIFF
--- a/content/includes/network.js
+++ b/content/includes/network.js
@@ -78,25 +78,15 @@ var network = {
           base_uri : "https://accounts.google.com/o/",
           //redirect_uri : "urn:ietf:wg:oauth:2.0:oob:auto",
           scope : "https://www.googleapis.com/auth/carddav https://www.googleapis.com/auth/calendar",
-          client_id : "",
-          client_secret : "",
+          client_id : dav.sync.prefSettings.getCharPref("OAuth2_ClientID"),
+          client_secret : dav.sync.prefSettings.getCharPref("OAuth2_ClientSecret"),
         }
         break;
       
       default:
         return null;
     }
-
-    let accountID = uri.username || ((configObject && configObject.hasOwnProperty("accountID")) ? configObject.accountID : null);
-    let accountData = null;
-
-    try {
-      accountData = new TbSync.AccountData(accountID);
-    } catch (e) {};
-
-	config.client_id = dav.sync.prefSettings.getCharPref("OAuth2_ClientID");
-	config.client_secret = dav.sync.prefSettings.getCharPref("OAuth2_ClientSecret");
-   
+    
     let oauth = new OAuth2(config.base_uri, config.scope, config.client_id, config.client_secret);
     oauth.requestWindowFeatures = "chrome,private,centerscreen,width=500,height=750";
 
@@ -115,6 +105,13 @@ var network = {
     // - it does not get lost during offline support disable/enable
     // - we can connect multiple google accounts without running into same-url-issue of shared calendars
     // - if called from lightning, we do not need to do an expensive url search to get the accountID
+    let accountID = uri.username || ((configObject && configObject.hasOwnProperty("accountID")) ? configObject.accountID : null);
+
+    let accountData = null;
+    try {
+      accountData = new TbSync.AccountData(accountID);
+    } catch (e) {};
+    
     if (configObject && configObject.hasOwnProperty("accountname")) {
       oauth.requestWindowTitle = "TbSync account <" + configObject.accountname + "> requests authorization.";
     } else if (accountData) {

--- a/content/includes/network.js
+++ b/content/includes/network.js
@@ -94,9 +94,8 @@ var network = {
       accountData = new TbSync.AccountData(accountID);
     } catch (e) {};
 
-	// Make sure we overload the default OAuth2 keys and secrets if set by user in the account db file.
-	config.client_id = accountData.getAccountProperty("oauth2_client_id");
-	config.client_secret = accountData.getAccountProperty("oauth2_client_secret");
+	config.client_id = dav.sync.prefSettings.getCharPref("OAuth2_ClientID");
+	config.client_secret = dav.sync.prefSettings.getCharPref("OAuth2_ClientSecret");
    
     let oauth = new OAuth2(config.base_uri, config.scope, config.client_id, config.client_secret);
     oauth.requestWindowFeatures = "chrome,private,centerscreen,width=500,height=750";

--- a/content/includes/network.js
+++ b/content/includes/network.js
@@ -78,15 +78,26 @@ var network = {
           base_uri : "https://accounts.google.com/o/",
           //redirect_uri : "urn:ietf:wg:oauth:2.0:oob:auto",
           scope : "https://www.googleapis.com/auth/carddav https://www.googleapis.com/auth/calendar",
-          client_id : "689460414096-e4nddn8tss5c59glidp4bc0qpeu3oper.apps.googleusercontent.com",
-          client_secret : "LeTdF3UEpCvP1V3EBygjP-kl",
+          client_id : "",
+          client_secret : "",
         }
         break;
       
       default:
         return null;
     }
-    
+
+    let accountID = uri.username || ((configObject && configObject.hasOwnProperty("accountID")) ? configObject.accountID : null);
+    let accountData = null;
+
+    try {
+      accountData = new TbSync.AccountData(accountID);
+    } catch (e) {};
+
+	// Make sure we overload the default OAuth2 keys and secrets if set by user in the account db file.
+	config.client_id = accountData.getAccountProperty("oauth2_client_id");
+	config.client_secret = accountData.getAccountProperty("oauth2_client_secret");
+   
     let oauth = new OAuth2(config.base_uri, config.scope, config.client_id, config.client_secret);
     oauth.requestWindowFeatures = "chrome,private,centerscreen,width=500,height=750";
 
@@ -105,13 +116,6 @@ var network = {
     // - it does not get lost during offline support disable/enable
     // - we can connect multiple google accounts without running into same-url-issue of shared calendars
     // - if called from lightning, we do not need to do an expensive url search to get the accountID
-    let accountID = uri.username || ((configObject && configObject.hasOwnProperty("accountID")) ? configObject.accountID : null);
-
-    let accountData = null;
-    try {
-      accountData = new TbSync.AccountData(accountID);
-    } catch (e) {};
-    
     if (configObject && configObject.hasOwnProperty("accountname")) {
       oauth.requestWindowTitle = "TbSync account <" + configObject.accountname + "> requests authorization.";
     } else if (accountData) {

--- a/content/provider.js
+++ b/content/provider.js
@@ -186,6 +186,9 @@ var Base = class {
             "https" : true, //deprecated
             "createdWithProviderVersion" : "0",
             "syncGroups" : false,
+            
+            "oauth2_client_id" : "689460414096-e4nddn8tss5c59glidp4bc0qpeu3oper.apps.googleusercontent.com",
+            "oauth2_client_secret" : "LeTdF3UEpCvP1V3EBygjP-kl",
             }; 
         return row;
     }

--- a/content/provider.js
+++ b/content/provider.js
@@ -28,6 +28,8 @@ var Base = class {
         branch.setCharPref("clientID.type", "TbSync");
         branch.setCharPref("clientID.useragent", "Thunderbird CalDAV/CardDAV");    
         branch.setBoolPref("enforceUniqueCalendarUrls", false);    
+        branch.setCharPref("OAuth2_ClientID", "689460414096-e4nddn8tss5c59glidp4bc0qpeu3oper.apps.googleusercontent.com");
+        branch.setCharPref("OAuth2_ClientSecret", "LeTdF3UEpCvP1V3EBygjP-kl");
 
         dav.openWindows = {};
 
@@ -186,9 +188,6 @@ var Base = class {
             "https" : true, //deprecated
             "createdWithProviderVersion" : "0",
             "syncGroups" : false,
-            
-            "oauth2_client_id" : "689460414096-e4nddn8tss5c59glidp4bc0qpeu3oper.apps.googleusercontent.com",
-            "oauth2_client_secret" : "LeTdF3UEpCvP1V3EBygjP-kl",
             }; 
         return row;
     }


### PR DESCRIPTION
Two new `AccountProperties` were added (`oauth2_client_id` and `oauth2_client_token`) to allow manual change of the default OAuth2 tokens hardcoded in DAV-4-TbSync. While this is not changing anything from regular user's perspective, it allows power user to enter his own set of OAuth2 API tokens directly into the account db file.

This can be used as a workaround to infrequent but rising amount of errors because the project is starting to reach the maximum limit of daily requests via the default set of OAuth2 tokens hardcoded inside.

In the future, this shall have it's own place in settings somewhere in the GUI.