### PR TITLE
Sort addressbook autocomplete entries by popularity...

### DIFF
--- a/content/provider.js
+++ b/content/provider.js
@@ -308,6 +308,7 @@ var Base = class {
                                 icon: dav.Base.getProviderIcon(16, accountData),
                                 // https://bugzilla.mozilla.org/show_bug.cgi?id=1653213
                                 style: "dav4tbsync-abook",
+                                popularityIndex: parseInt(card.getProperty("PopularityIndex", "0")),
                             });
                         
                         } else {                        
@@ -329,6 +330,7 @@ var Base = class {
                                     icon: dav.Base.getProviderIcon(16, accountData),
                                     // https://bugzilla.mozilla.org/show_bug.cgi?id=1653213
                                     style: "dav4tbsync-abook",				    
+                                    popularityIndex: parseInt(card.getProperty("PopularityIndex", "0")),
                                 });
                             }
                             
@@ -338,6 +340,16 @@ var Base = class {
             }
         }
         
+        // Sort the results.
+        entries.sort(function(a, b) {
+          // Order by 1) descending popularity,
+          // then 2) by value (DisplayName) sorted alphabetically.
+          return (
+            b.popularityIndex - a.popularityIndex ||
+            a.value.localeCompare(b.value)
+          );
+        });
+
         return entries;
     }
 


### PR DESCRIPTION
…Fix for TbSync issue 363; https://github.com/jobisoft/TbSync/issues/363

This uses a similar sort to Thunderbird's internal address book, using the existing card's PopularityIndex field, to sort the auto-complete entries before passing back to the TbSync module.

This version appears to work for my use case, with a single DAV provider, but makes no attempt to work across different providers. I don't know how important that is; do many users actually have a mix of providers?
It is not immediately clear to me whether the EAS provider also supports the PopularityIndex field, and I myself don't have any way of testing this. If it does, then in fact it would make more sense to also fill in the popularityIndex in that provider, and then do the (simple) sorting within TbSync itself (approx location would be line 160 of abAutoComplete.js)
